### PR TITLE
Leapp actions on Hosts page and host detail

### DIFF
--- a/app/helpers/concerns/foreman_leapp/hosts_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_leapp/hosts_helper_extensions.rb
@@ -2,13 +2,14 @@
 
 module ForemanLeapp
   module HostsHelperExtensions
-    extend ActiveSupport::Concern
-
-    included do
-      # execute callbacks
+    def multiple_actions
+      super + [[_('Preupgrade check with Leapp'), new_job_invocation_path(feature: 'leapp_preupgrade'), false],
+               [_('Upgrade with Leapp'), new_job_invocation_path(feature: 'leapp_upgrade'), false]]
     end
 
-    # create or overwrite instance methods...
-    def instance_method_name; end
+    def rex_host_features(*args)
+      super + [link_to(_('Preupgrade check with Leapp'), new_job_invocation_path(:host_ids => [args.first.id], :feature => 'leapp_preupgrade')),
+               link_to(_('Upgrade with Leapp'), new_job_invocation_path(:host_ids => [args.first.id], :feature => 'leapp_upgrade'))]
+    end
   end
 end

--- a/app/views/foreman_leapp/job_templates/preupgrade.erb
+++ b/app/views/foreman_leapp/job_templates/preupgrade.erb
@@ -4,6 +4,7 @@ name: Run preupgrade via Leapp
 job_category: Leapp
 description_format: 'Upgradeability check for RHEL 7 host'
 provider_type: SSH
+feature: leapp_preupgrade
 template_inputs:
 - name: leapp_auth_token_input
   description: foreman user token to use with Leapp for foreman_leapp API access

--- a/app/views/foreman_leapp/job_templates/upgrade.erb
+++ b/app/views/foreman_leapp/job_templates/upgrade.erb
@@ -4,6 +4,7 @@ name: Run upgrade via Leapp
 job_category: Leapp
 description_format: 'Upgrade RHEL 7 host'
 provider_type: SSH
+feature: leapp_upgrade
 template_inputs:
 - name: reboot
   description: reboot the vm automaticaly to continue with the upgrade

--- a/foreman_leapp.gemspec
+++ b/foreman_leapp.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib,locale}/**/*'] + ['LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 
+  s.add_dependency 'foreman_remote_execution'
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'rubocop'
-  s.add_development_dependency 'foreman_remote_execution'
 end

--- a/foreman_leapp.gemspec
+++ b/foreman_leapp.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'foreman_remote_execution'
 end

--- a/lib/foreman_leapp/engine.rb
+++ b/lib/foreman_leapp/engine.rb
@@ -30,10 +30,24 @@ module ForemanLeapp
     config.to_prepare do
       begin
         Host::Managed.include ForemanLeapp::HostExtensions
-        HostsHelper.include ForemanLeapp::HostsHelperExtensions
+        HostsHelper.prepend ForemanLeapp::HostsHelperExtensions
       rescue StandardError => e
         Rails.logger.warn "ForemanLeapp: skipping engine hook (#{e})"
       end
+
+      RemoteExecutionFeature.register(
+          :leapp_preupgrade,
+          N_('Preupgrade check with Leapp'),
+          :description => N_('Upgradeability check for RHEL 7 host'),
+          :host_action_button => false
+      )
+
+      RemoteExecutionFeature.register(
+          :leapp_upgrade,
+          N_('Upgrade with Leapp'),
+          :description => N_('Run Leapp upgrade job for RHEL 7 host'),
+          :host_action_button => false
+      )
     end
 
     rake_tasks do


### PR DESCRIPTION
Requires: 
[Fixes #29369 - Add support for URL with parameters in Hosts bulk actions](https://github.com/theforeman/foreman/pull/7529)
[Fixes #29399 - Make schedule_job_multi_button method extendable](https://github.com/theforeman/foreman_remote_execution/pull/480)
Based on: [Move Leapp job templates to category 'Leapp' ](https://github.com/oamg/foreman_leapp/pull/6)