### PR TITLE
Remove debug option from Leapp job templates

### DIFF
--- a/app/views/foreman_leapp/job_templates/preupgrade.erb
+++ b/app/views/foreman_leapp/job_templates/preupgrade.erb
@@ -5,11 +5,6 @@ job_category: Leapp
 description_format: 'Upgradeability check for RHEL 7 host'
 provider_type: SSH
 template_inputs:
-- name: debug
-  description: enabling --debug option of Leapp
-  input_type: user
-  required: false
-  options: "true\nfalse"
 - name: leapp_auth_token_input
   description: foreman user token to use with Leapp for foreman_leapp API access
   input_type: variable
@@ -22,7 +17,7 @@ template_inputs:
   variable_name: "leapp_auth_user"
 %>
 
-leapp preupgrade <%= "--debug" if input('debug') == "true" %>
+leapp preupgrade
 # XXX FIXME probably will be moved to client
 echo "{\"preupgrade_report\": $(cat /var/log/leapp/leapp-report.json), \"host\": \"<%=@host.name%>\", \"status\": $(echo $?)}" > /tmp/foreman_leapp_preupgrade.json
 curl -H 'Content-Type: application/json' -u <%=input('leapp_auth_user_input')%>:<%=input('leapp_auth_token_input')%> -X POST <%=foreman_server_url%>/api/v2/preupgrade_reports -d @/tmp/foreman_leapp_preupgrade.json

--- a/app/views/foreman_leapp/job_templates/upgrade.erb
+++ b/app/views/foreman_leapp/job_templates/upgrade.erb
@@ -5,11 +5,6 @@ job_category: Leapp
 description_format: 'Upgrade RHEL 7 host'
 provider_type: SSH
 template_inputs:
-- name: debug
-  description: enabling --debug option of Leapp
-  input_type: user
-  required: false
-  options: "true\nfalse"
 - name: reboot
   description: reboot the vm automaticaly to continue with the upgrade
   input_type: user
@@ -17,4 +12,4 @@ template_inputs:
   options: "false\ntrue"
 %>
 
-leapp upgrade <%= "--debug" if input('debug') == "true" %> <%= "--reboot" if input('reboot') == "true" %>
+leapp upgrade <%= "--reboot" if input('reboot') == "true" %>


### PR DESCRIPTION
Context:
`--debug` option cause very very long which can case performance problems (aka running it on 1000 hosts)
There is actually no use case for it, if admin wants to debug host, he can do it directly via ssh.