### PR TITLE
Add js link script for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "tfm-lint --plugin -d /webpack",
+    "link-leapp-js": "./script/link_leapp_js.sh",
     "test": "tfm-test --plugin",
     "test:watch": "tfm-test --plugin --watchAll",
     "test:current": "tfm-test --plugin --watch",

--- a/script/link_leapp_js.sh
+++ b/script/link_leapp_js.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This script allows you to link your local leapp-report-ui
+#
+# This script designed to run using `npm run link-leapp-js` in foreman_leapp root
+
+set -e
+
+if [[ -z "${JS_LOCATION}" ]]; then # JS_LOCATION is empty
+  JS_LOCATION="../leapp-report-ui"
+  echo "JS_LOCATION is not defined, location \"${JS_LOCATION}\" instead"
+elif [ ! -d "${JS_LOCATION}" ]; then
+  echo "Can't find folder ${JS_LOCATION}"
+  exit 1
+fi
+
+JS_INSTALL_LOCATION="$(pwd)/node_modules/leapp-report-ui"
+JS_LOCATION="$(pwd)/${JS_LOCATION}"
+
+if [ -L "${JS_INSTALL_LOCATION}" ]; then
+  unlink $JS_INSTALL_LOCATION
+fi
+
+set -x
+
+ln -s $JS_LOCATION $JS_INSTALL_LOCATION


### PR DESCRIPTION
Adds a new script that links compiled js from leapp-report-ui
for development. The script assumes foreman_leapp and
leapp-report-ui are in the same directory, but path can be modified.