### PR TITLE
Leapp - Fix for checking Job's category and feature

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,6 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: true
+
+Rails/HelperInstanceVariable:
+  Enabled: false

--- a/app/helpers/concerns/foreman_leapp/remote_execution_helper_extension.rb
+++ b/app/helpers/concerns/foreman_leapp/remote_execution_helper_extension.rb
@@ -3,13 +3,13 @@
 module ForemanLeapp
   module RemoteExecutionHelperExtension
     def job_invocation_task_buttons(task)
-      return super unless @job_invocation.remote_execution_feature&.label == 'leapp_remediation_plan'
+      return super unless ::Helpers::JobHelper.correct_feature?(@job_invocation, 'leapp_remediation_plan')
 
       super.insert(2, link_to(_('Rerun preupgrade check'),
-                      new_job_invocation_path(host_ids: @resource_base.map(&:id), feature: 'leapp_preupgrade'),
-                      class: 'btn btn-default',
-                      title: _('Run Leapp Preupgrade check again'),
-                      method: :get))
+                              new_job_invocation_path(host_ids: @resource_base.map(&:id), feature: 'leapp_preupgrade'),
+                              class: 'btn btn-default',
+                              title: _('Run Leapp Preupgrade check again'),
+                              method: :get))
     end
   end
 end

--- a/app/lib/actions/preupgrade_job.rb
+++ b/app/lib/actions/preupgrade_job.rb
@@ -7,8 +7,8 @@ module Actions
         Actions::RemoteExecution::RunHostJob
       end
 
-      def plan(job_invocation, host, _template_invocation, *_args)
-        return unless leapp_preupgrade_job?(job_invocation)
+      def plan(job_invocation, host, *_args)
+        return unless ::Helpers::JobHelper.correct_feature?(job_invocation, 'leapp_preupgrade')
 
         plan_self(host_id: host.id, job_invocation_id: job_invocation.id)
       end
@@ -29,11 +29,6 @@ module Actions
                            .reject(&:empty?)
                            .join('')
         JSON.parse(output)
-      end
-
-      def leapp_preupgrade_job?(job_invocation)
-        job_invocation.job_category == ::ForemanLeapp::JOB_CATEGORY &&
-          job_invocation.remote_execution_feature&.label == 'leapp_preupgrade'
       end
     end
   end

--- a/app/lib/helpers/job_helper.rb
+++ b/app/lib/helpers/job_helper.rb
@@ -5,7 +5,8 @@ module Helpers
     class << self
       def correct_feature?(job_invocation, feature)
         job_invocation.job_category == ::ForemanLeapp::JOB_CATEGORY &&
-          RemoteExecutionFeature.find_by(job_template_id: job_invocation.template_invocations[0]
+          RemoteExecutionFeature.find_by(job_template_id: job_invocation.pattern_template_invocations
+                                                                        .first
                                                                         &.template_id)
             &.label == feature
       end

--- a/app/lib/helpers/job_helper.rb
+++ b/app/lib/helpers/job_helper.rb
@@ -6,9 +6,8 @@ module Helpers
       def correct_feature?(job_invocation, feature)
         job_invocation.job_category == ::ForemanLeapp::JOB_CATEGORY &&
           RemoteExecutionFeature.find_by(job_template_id: job_invocation.pattern_template_invocations
-                                                                        .first
-                                                                        &.template_id)
-            &.label == feature
+                                                                        .pluck(:template_id)
+                                                                        .first)&.label == feature
       end
     end
   end

--- a/app/lib/helpers/job_helper.rb
+++ b/app/lib/helpers/job_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Helpers
+  module JobHelper
+    class << self
+      def correct_feature?(job_invocation, feature)
+        job_invocation.job_category == ::ForemanLeapp::JOB_CATEGORY &&
+          RemoteExecutionFeature.find_by(job_template_id: job_invocation.template_invocations[0]
+                                                                        &.template_id)
+            &.label == feature
+      end
+    end
+  end
+end

--- a/lib/foreman_leapp/engine.rb
+++ b/lib/foreman_leapp/engine.rb
@@ -11,6 +11,7 @@ module ForemanLeapp
     config.autoload_paths += Dir["#{config.root}/app/helpers/concerns"]
     config.autoload_paths += Dir["#{config.root}/app/models/concerns"]
     config.autoload_paths += Dir["#{config.root}/app/overrides"]
+    config.autoload_paths += Dir["#{config.root}/app/lib/helpers"]
     config.autoload_paths += Dir["#{config.root}/test/"]
 
     # Add any db migrations
@@ -31,7 +32,7 @@ module ForemanLeapp
                          partial: 'job_invocations/leapp_preupgrade_report',
                          name: _('Leapp preupgrade report'),
                          id: 'leapp_preupgrade_report',
-                         onlyif: proc { |subject| subject.remote_execution_feature&.label == 'leapp_preupgrade' }
+                         onlyif: proc { |subject| ::Helpers::JobHelper.correct_feature?(subject, 'leapp_preupgrade') }
         end
       end
     end

--- a/test/unit/actions/preupgrade_job_test.rb
+++ b/test/unit/actions/preupgrade_job_test.rb
@@ -6,40 +6,28 @@ module ForemanLeapp
   class PreupgradeJobTest < ActiveSupport::TestCase
     include Dynflow::Testing
 
-    let(:rex_feature) { RemoteExecutionFeature.find_by(label: 'leapp_preupgrade') }
-    let(:job_invocation) do
-      FactoryBot.create(:job_invocation, :with_task, :with_template,
-                        job_category: ::ForemanLeapp::JOB_CATEGORY,
-                        remote_execution_feature: rex_feature)
+    let(:host) { FactoryBot.create(:host) }
+    let(:job_template) do
+      FactoryBot.create(:job_template, template: 'echo "1"', job_category: 'leapp',
+                                       provider_type: 'SSH', name: 'Leapp preupgrade')
     end
-    let(:template_invocation) { job_invocation.template_invocations.first }
-    let(:host) { template_invocation.host }
+    let(:job_invocation) { FactoryBot.create(:job_invocation, job_category: ::ForemanLeapp::JOB_CATEGORY) }
+    let(:template_invocation) do
+      FactoryBot.create(:template_invocation, template: job_template, host: host,
+                                              job_invocation: job_invocation)
+    end
 
     let(:action) { create_action(Actions::ForemanLeapp::PreupgradeJob) }
     let(:planned_action) { plan_action(action, job_invocation, host, template_invocation) }
+
+    setup do
+      RemoteExecutionFeature.find_by(label: 'leapp_preupgrade').update(job_template: job_template)
+    end
 
     describe 'plan' do
       test 'run plan phase' do
         assert_equal planned_action.input['host_id'], host.id
         assert_equal planned_action.input['job_invocation_id'], job_invocation.id
-      end
-    end
-
-    describe '#correct_category?' do
-      it 'correct category & feature' do
-        assert action.send(:leapp_preupgrade_job?, FactoryBot.build(:job_invocation,
-                                                                    job_category: ::ForemanLeapp::JOB_CATEGORY,
-                                                                    remote_execution_feature: rex_feature))
-      end
-
-      it 'wrong category' do
-        assert_not action.send(:leapp_preupgrade_job?, FactoryBot.build(:job_invocation,
-                                                                        remote_execution_feature: rex_feature))
-      end
-
-      it 'wrong feature' do
-        assert_not action.send(:leapp_preupgrade_job?, FactoryBot.build(:job_invocation,
-                                                                        job_category: ::ForemanLeapp::JOB_CATEGORY))
       end
     end
 

--- a/test/unit/actions/preupgrade_job_test.rb
+++ b/test/unit/actions/preupgrade_job_test.rb
@@ -13,8 +13,7 @@ module ForemanLeapp
     end
     let(:job_invocation) { FactoryBot.create(:job_invocation, job_category: ::ForemanLeapp::JOB_CATEGORY) }
     let(:template_invocation) do
-      FactoryBot.create(:template_invocation, template: job_template, host: host,
-                                              job_invocation: job_invocation)
+      FactoryBot.create(:template_invocation, template: job_template, job_invocation: job_invocation)
     end
 
     let(:action) { create_action(Actions::ForemanLeapp::PreupgradeJob) }

--- a/test/unit/helpers/job_helper_test.rb
+++ b/test/unit/helpers/job_helper_test.rb
@@ -5,7 +5,7 @@ require 'test_plugin_helper'
 module Helpers
   class JobHelperTest < ActionView::TestCase
     let(:helper) { ::Helpers::JobHelper }
-    let(:host) { FactoryBot.create(:host) }
+    # let(:host) { FactoryBot.create(:host) }
     let(:job_template) do
       FactoryBot.create(:job_template, template: 'echo "1"', job_category: 'leapp',
                                        provider_type: 'SSH', name: 'Leapp preupgrade')
@@ -15,7 +15,7 @@ module Helpers
     describe 'correct_feature?' do
       setup do
         RemoteExecutionFeature.find_by(label: 'leapp_preupgrade').update(job_template: job_template)
-        FactoryBot.create(:template_invocation, template: job_template, host: host, job_invocation: job_invocation)
+        FactoryBot.create(:template_invocation, template: job_template, job_invocation: job_invocation)
       end
 
       it 'correct category & feature' do
@@ -24,7 +24,7 @@ module Helpers
 
       it 'wrong category' do
         job_invocation = FactoryBot.create(:job_invocation, job_category: 'NOPE')
-        FactoryBot.create(:template_invocation, template: job_template, host: host, job_invocation: job_invocation)
+        FactoryBot.create(:template_invocation, template: job_template, job_invocation: job_invocation)
 
         assert_not helper.correct_feature?(job_invocation, 'leapp_preupgrade')
       end

--- a/test/unit/helpers/job_helper_test.rb
+++ b/test/unit/helpers/job_helper_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+module Helpers
+  class JobHelperTest < ActionView::TestCase
+    let(:helper) { ::Helpers::JobHelper }
+    let(:host) { FactoryBot.create(:host) }
+    let(:job_template) do
+      FactoryBot.create(:job_template, template: 'echo "1"', job_category: 'leapp',
+                                       provider_type: 'SSH', name: 'Leapp preupgrade')
+    end
+    let(:job_invocation) { FactoryBot.create(:job_invocation, job_category: ::ForemanLeapp::JOB_CATEGORY) }
+
+    describe 'correct_feature?' do
+      setup do
+        RemoteExecutionFeature.find_by(label: 'leapp_preupgrade').update(job_template: job_template)
+        FactoryBot.create(:template_invocation, template: job_template, host: host, job_invocation: job_invocation)
+      end
+
+      it 'correct category & feature' do
+        assert helper.correct_feature?(job_invocation, 'leapp_preupgrade')
+      end
+
+      it 'wrong category' do
+        job_invocation = FactoryBot.create(:job_invocation, job_category: 'NOPE')
+        FactoryBot.create(:template_invocation, template: job_template, host: host, job_invocation: job_invocation)
+
+        assert_not helper.correct_feature?(job_invocation, 'leapp_preupgrade')
+      end
+
+      it 'wrong feature' do
+        assert_not helper.correct_feature?(job_invocation, 'leapp_preupgrade2')
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Issue**
Before the fix, I used simple check for job's feature, like this:
```
@job_invocation.remote_execution_feature&.label == 'leapp_preupgrade'
```
Problem with this is, that if you run job invocation without feature (just select job category `leapp` and type `leapp_preupgrade`), this condition will fail. But the from user's perspective, job is still `leapp preupgrade`, so it shouldn't fail.

**Steps to reproduce**
* Go to `/job_invocations/new?feature=leapp_remediation_plan`
* Select hosts, add some fake ids and submit
Button `Rerun preupgrade check` is displayed
* Go to `/job_invocations/new`, this time select category and template manually
Button `Rerun preupgrade check` IS NOT displayed

**Fix**
Instead of checking fixture on job_invocation, I'm checking job's template invocations.

**Affected code:**
* Leapp preuprgrade tab on the job invocation page
* Planning of PreupgradeJob
* Rerun preupgrade button on Remediation job page

**Known issue**
https://github.com/oamg/foreman_leapp/issues/39 (but with this fix, tab is not displayed at all, you need to refresh the page)