### PR TITLE
Change REX version from 3.1.0 to 3.1

### DIFF
--- a/foreman_leapp.gemspec
+++ b/foreman_leapp.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib,locale}/**/*'] + ['LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'foreman_remote_execution', '~> 3.1.0'
+  s.add_dependency 'foreman_remote_execution', '~> 3.1'
   s.add_development_dependency 'rdoc', '~> 6.2'
   s.add_development_dependency 'rubocop', '~> 0.80'
 end


### PR DESCRIPTION
Requiring version 3.1.0 caused in packaging:
```
Requires: %{?scl_prefix}rubygem(foreman_remote_execution) >= 3.1.0
Requires: %{?scl_prefix}rubygem(foreman_remote_execution) < 3.2
```
Mhulan's comment:

> this may be too strict, REX don't change that dramatically, I'd personally remove this line entirely but that means we should update the gemspec too and set the rex dependency as >= 3.1 at

See https://github.com/theforeman/foreman-packaging/pull/4986