### PR TITLE
Leapp - Fix issue for SQlite migration

### DIFF
--- a/db/migrate/20200327091009_add_host_to_report.rb
+++ b/db/migrate/20200327091009_add_host_to_report.rb
@@ -1,6 +1,12 @@
 class AddHostToReport < ActiveRecord::Migration[5.2]
-  def change
-    add_column :preupgrade_report_entries, :host_id, :integer, null: false
+  def up
+    add_column :preupgrade_report_entries, :host_id, :integer
+    change_column :preupgrade_report_entries, :host_id, :integer, null: false
     add_index :preupgrade_report_entries, :host_id
+  end
+
+  def down
+    remove_index :preupgrade_report_entries, :host_id
+    remove_column :preupgrade_report_entries, :host_id
   end
 end

--- a/lib/foreman_leapp/version.rb
+++ b/lib/foreman_leapp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ForemanLeapp
-  VERSION = '0.0.2'
+  VERSION = '0.0.3'
 end


### PR DESCRIPTION
Running migration on SQLite database were failing on error:
```
2020-04-15T14:18:43 [I|sql|] Migrating to AddHostToReport (20200327091009)
== 20200327091009 AddHostToReport: migrating ==================================
-- add_column(:preupgrade_report_entries, :host_id, :integer, {:null=>false})
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

SQLite3::SQLException: Cannot add a NOT NULL column with default value NULL: ALTER TABLE "preupgrade_report_entries" ADD "host_id" integer NOT NULL
/home/lstejskal/Projects/plugins/leapp/db/migrate/20200327091009_add_host_to_report.rb:3:in `change'
/home/lstejskal/.rbenv/versions/2.6.5/bin/bundle:23:in `load'
/home/lstejskal/.rbenv/versions/2.6.5/bin/bundle:23:in `<main>'

Caused by:
ActiveRecord::StatementInvalid: SQLite3::SQLException: Cannot add a NOT NULL column with default value NULL: ALTER TABLE "preupgrade_report_entries" ADD "host_id" integer NOT NULL
/home/lstejskal/Projects/plugins/leapp/db/migrate/20200327091009_add_host_to_report.rb:3:in `change'
/home/lstejskal/.rbenv/versions/2.6.5/bin/bundle:23:in `load'
/home/lstejskal/.rbenv/versions/2.6.5/bin/bundle:23:in `<main>'

Caused by:
SQLite3::SQLException: Cannot add a NOT NULL column with default value NULL
/home/lstejskal/Projects/plugins/leapp/db/migrate/20200327091009_add_host_to_report.rb:3:in `change'
/home/lstejskal/.rbenv/versions/2.6.5/bin/bundle:23:in `load'
/home/lstejskal/.rbenv/versions/2.6.5/bin/bundle:23:in `<main>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

Fixed by removed `NOT NULL` condition.