### PR TITLE
0.0.4 - Add webpack folder and package.json to gem files

### DIFF
--- a/foreman_leapp.gemspec
+++ b/foreman_leapp.gemspec
@@ -14,7 +14,9 @@ Gem::Specification.new do |s|
   s.summary     = 'A Foreman plugin for Leapp utility.'
   s.description = 'A Foreman plugin to support inplace RHEL 7 -> RHEL 8 upgrades with Leapp utility.'
 
-  s.files = Dir['{app,config,db,lib,locale}/**/*'] + ['LICENSE', 'Rakefile', 'README.md']
+  s.files = Dir['{app,config,db,lib,locale,webpack}/**/*'] +
+            ['LICENSE', 'Rakefile', 'README.md'] +
+            ['package.json']
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'foreman_remote_execution', '~> 3.1'

--- a/lib/foreman_leapp/version.rb
+++ b/lib/foreman_leapp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ForemanLeapp
-  VERSION = '0.0.3'
+  VERSION = '0.0.4'
 end


### PR DESCRIPTION
Fix for packaging error:
```
Processing files: tfm-rubygem-foreman_leapp-doc-0.0.3-1.fm2_1.el7.noarch
error: File not found: /builddir/build/BUILDROOT/tfm-rubygem-foreman_leapp-0.0.3-1.fm2_1.el7.noarch/opt/theforeman/tfm/root/usr/share/gems/gems/foreman_leapp-0.0.3/foreman_leapp.gemspec
RPM build errors:
    File not found: /builddir/build/BUILDROOT/tfm-rubygem-foreman_leapp-0.0.3-1.fm2_1.el7.noarch/opt/theforeman/tfm/root/usr/share/gems/gems/foreman_leapp-0.0.3/package.json
    File not found: /builddir/build/BUILDROOT/tfm-rubygem-foreman_leapp-0.0.3-1.fm2_1.el7.noarch/opt/theforeman/tfm/root/usr/share/gems/gems/foreman_leapp-0.0.3/webpack
    File listed twice: /opt/theforeman/tfm/root/usr/share/gems/gems/foreman_leapp-0.0.3/LICENSE
    File not found: /builddir/build/BUILDROOT/tfm-rubygem-foreman_leapp-0.0.3-1.fm2_1.el7.noarch/opt/theforeman/tfm/root/usr/share/gems/gems/foreman_leapp-0.0.3/foreman_leapp.gemspec
Child return code was: 1
EXCEPTION: [Error()]
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py", line 95, in trace
    result = func(*args, **kw)
  File "/usr/lib/python3.6/site-packages/mockbuild/util.py", line 746, in do_with_status
    raise exception.Error("Command failed: \n # %s\n%s" % (command, output), child.returncode)
mockbuild.exception.Error: Command failed: 
 # bash --login -c /usr/bin/rpmbuild -bb --target noarch --nodeps /builddir/build/SPECS/rubygem-foreman_leapp.spec

```