### PR TITLE
PreupgradeReports ApiPie documentation

### DIFF
--- a/lib/foreman_leapp/engine.rb
+++ b/lib/foreman_leapp/engine.rb
@@ -25,6 +25,7 @@ module ForemanLeapp
       Foreman::Plugin.register :foreman_leapp do
         requires_foreman '>= 1.16'
 
+        apipie_documented_controllers ["#{ForemanLeapp::Engine.root}/app/controllers/api/v2/*.rb"]
         extend_template_helpers ForemanLeapp::TemplateHelper
 
         extend_page 'job_invocations/show' do |cx|
@@ -90,6 +91,10 @@ module ForemanLeapp
     initializer('foreman_leapp.extend_remote_execution',
                 after: 'foreman_leapp.require_foreman_remote_execution') do |_app|
       RemoteExecutionHelper.prepend ForemanLeapp::RemoteExecutionHelperExtension
+    end
+
+    initializer 'foreman_leapp.apipie' do
+      Apipie.configuration.checksum_path += ['/api/']
     end
   end
 end

--- a/lib/foreman_leapp/version.rb
+++ b/lib/foreman_leapp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ForemanLeapp
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end


### PR DESCRIPTION
* Make ApiPie documentation great again. PreupgradeReports now available in `/apidoc`
* Bump version to 0.0.5