### PR TITLE
Fixes #29978 - Fix for uninitialized constant Host::JobInvocation

### DIFF
--- a/lib/foreman_leapp/engine.rb
+++ b/lib/foreman_leapp/engine.rb
@@ -45,7 +45,7 @@ module ForemanLeapp
     config.to_prepare do
       begin
         HostsHelper.prepend ForemanLeapp::HostsHelperExtensions
-        Host::JobInvocation.include ForemanLeapp::JobInvocationExtensions
+        JobInvocation.include ForemanLeapp::JobInvocationExtensions
       rescue StandardError => e
         Rails.logger.warn "ForemanLeapp: skipping engine hook (#{e})"
       end

--- a/lib/foreman_leapp/engine.rb
+++ b/lib/foreman_leapp/engine.rb
@@ -44,8 +44,8 @@ module ForemanLeapp
     # Include concerns in this config.to_prepare block
     config.to_prepare do
       begin
-        HostsHelper.prepend ForemanLeapp::HostsHelperExtensions
-        JobInvocation.include ForemanLeapp::JobInvocationExtensions
+        ::HostsHelper.prepend ForemanLeapp::HostsHelperExtensions
+        ::JobInvocation.include ForemanLeapp::JobInvocationExtensions
       rescue StandardError => e
         Rails.logger.warn "ForemanLeapp: skipping engine hook (#{e})"
       end


### PR DESCRIPTION
**Issue**
Skipping engine hook (uninitialized constant Host::JobInvocation) during plugin initialization.

**How to reproduce the issue**
* Add `binding.pry` before `Host::JobInvocation.include ForemanLeapp::JobInvocationExtensions`
* In `pry`:
```
[1] pry(#<#<Class:0x000000000a5940c0>>)> Host::JobInvocation
=> JobInvocation(id: integer, targeting_id: integer, job_category: string, task_id: uuid, task_group_id: integer, triggering_id: integer, description: string, concurrency_level: integer, time_span: integer, execution_timeout_interval: integer, password: string, key_passphrase: string, remote_execution_feature_id: integer, sudo_password: string)

[2] pry(#<#<Class:0x000000000a5940c0>>)> Host::JobInvocation
NameError: uninitialized constant Host::JobInvocation
from /home/lstejskal/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/active_support.rb:61:in `block in load_missing_constant'
[3] pry(#<#<Class:0x000000000a5940c0>>)> 
```
**Fix**
Hook only `JobInvocation` instead of `Host::JobInvocation`