### PR TITLE
Fixes #37909 - move css import from vendor to foreman

### DIFF
--- a/webpack/components/PreupgradeReportsList/PreupgradeReportList.scss
+++ b/webpack/components/PreupgradeReportsList/PreupgradeReportList.scss
@@ -1,4 +1,4 @@
-@import '~@theforeman/vendor/scss/variables';
+@import 'foremanReact/common/variables';
 
 #preupgrade-report-entries-list-view {
   .sortable-header {

--- a/webpack/components/PreupgradeReportsList/components/foreman_leapp.scss
+++ b/webpack/components/PreupgradeReportsList/components/foreman_leapp.scss
@@ -1,4 +1,4 @@
-@import '~@theforeman/vendor/scss/variables';
+@import 'foremanReact/common/variables';
 
 .top-padded {
   padding-top: 8px;


### PR DESCRIPTION
css imports were moved in https://github.com/theforeman/foreman/pull/10345 already
and will break now that https://github.com/theforeman/foreman/pull/10342 is merged.
