### PR TITLE
Fixes #39051 - Add expandable info to leapp reports

### DIFF
--- a/webpack/components/PreupgradeReportsTable/PreupgradeReportsTable.scss
+++ b/webpack/components/PreupgradeReportsTable/PreupgradeReportsTable.scss
@@ -1,0 +1,5 @@
+.leapp-report-details {
+  dd {
+    white-space: pre-wrap;
+  }
+}

--- a/webpack/components/PreupgradeReportsTable/ReportDetails.js
+++ b/webpack/components/PreupgradeReportsTable/ReportDetails.js
@@ -1,0 +1,134 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  Label,
+  LabelGroup,
+} from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+import './PreupgradeReportsTable.scss';
+
+export const renderSeverityLabel = severity => {
+  switch (severity) {
+    case 'high':
+      return <Label color="red">{__('High')}</Label>;
+    case 'medium':
+      return <Label color="orange">{__('Medium')}</Label>;
+    case 'low':
+      return <Label color="blue">{__('Low')}</Label>;
+    case 'info':
+      return <Label color="grey">{__('Info')}</Label>;
+    default:
+      return <Label color="grey">{severity || __('Info')}</Label>;
+  }
+};
+
+const ReportDetails = ({ entry }) => (
+  <DescriptionList isHorizontal isCompact className="leapp-report-details">
+    {entry.title && (
+      <DescriptionListGroup>
+        <DescriptionListTerm>{__('Title')}</DescriptionListTerm>
+        <DescriptionListDescription>{entry.title}</DescriptionListDescription>
+      </DescriptionListGroup>
+    )}
+
+    {entry.severity && (
+      <DescriptionListGroup>
+        <DescriptionListTerm>{__('Risk Factor')}</DescriptionListTerm>
+        <DescriptionListDescription>
+          {renderSeverityLabel(entry.severity)}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+    )}
+
+    {entry.summary && (
+      <DescriptionListGroup>
+        <DescriptionListTerm>{__('Summary')}</DescriptionListTerm>
+        <DescriptionListDescription>{entry.summary}</DescriptionListDescription>
+      </DescriptionListGroup>
+    )}
+
+    {entry.tags && entry.tags.length > 0 && (
+      <DescriptionListGroup>
+        <DescriptionListTerm>{__('Tags')}</DescriptionListTerm>
+        <DescriptionListDescription>
+          <LabelGroup>
+            {entry.tags.map(tag => (
+              <Label key={tag} color="blue">
+                {tag}
+              </Label>
+            ))}
+          </LabelGroup>
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+    )}
+
+    {entry.detail?.external?.filter(link => link.url).length > 0 && (
+      <DescriptionListGroup>
+        <DescriptionListTerm>{__('Links')}</DescriptionListTerm>
+        <DescriptionListDescription>
+          {entry.detail.external
+            .filter(link => link.url)
+            .map((item, i) => (
+              <div key={item.url || i}>
+                <a href={item.url} target="_blank" rel="noopener noreferrer">
+                  {item.title || item.url}
+                </a>
+              </div>
+            ))}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+    )}
+
+    {entry.detail?.remediations?.length > 0 &&
+      entry.detail.remediations.map((item, i) => (
+        <DescriptionListGroup key={`remediations-${i}`}>
+          <DescriptionListTerm>
+            {item.type === 'command' ? __('Command') : __('Hint')}
+          </DescriptionListTerm>
+          <DescriptionListDescription>
+            {item.type === 'command' ? (
+              <code>
+                {Array.isArray(item.context)
+                  ? item.context.join(' ')
+                  : item.context}
+              </code>
+            ) : (
+              item.context
+            )}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      ))}
+  </DescriptionList>
+);
+
+ReportDetails.propTypes = {
+  entry: PropTypes.shape({
+    title: PropTypes.string,
+    severity: PropTypes.string,
+    summary: PropTypes.string,
+    tags: PropTypes.arrayOf(PropTypes.string),
+    detail: PropTypes.shape({
+      external: PropTypes.arrayOf(
+        PropTypes.shape({
+          url: PropTypes.string,
+          title: PropTypes.string,
+        })
+      ),
+      remediations: PropTypes.arrayOf(
+        PropTypes.shape({
+          type: PropTypes.string,
+          context: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.arrayOf(PropTypes.string),
+          ]),
+        })
+      ),
+    }),
+  }).isRequired,
+};
+
+export default ReportDetails;

--- a/webpack/components/PreupgradeReportsTable/index.js
+++ b/webpack/components/PreupgradeReportsTable/index.js
@@ -1,35 +1,25 @@
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { ExpandableSection, Label, Tooltip } from '@patternfly/react-core';
+import { ExpandableSection, Tooltip } from '@patternfly/react-core';
+import { ExpandableRowContent, Tbody, Td, Tr } from '@patternfly/react-table';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { Table } from 'foremanReact/components/PF4/TableIndexPage/Table/Table';
+import { getColumnHelpers } from 'foremanReact/components/PF4/TableIndexPage/Table/helpers';
 import { APIActions } from 'foremanReact/redux/API';
 import { STATUS } from 'foremanReact/constants';
-
 import { entriesPage } from '../PreupgradeReports/PreupgradeReportsHelpers';
-
-const renderSeverityLabel = severity => {
-  switch (severity) {
-    case 'high':
-      return <Label color="red">{__('High')}</Label>;
-    case 'medium':
-      return <Label color="orange">{__('Medium')}</Label>;
-    case 'low':
-      return <Label color="blue">{__('Low')}</Label>;
-    case 'info':
-      return <Label color="grey">{__('Info')}</Label>;
-    default:
-      return <Label color="grey">{severity || __('Info')}</Label>;
-  }
-};
+import ReportDetails, { renderSeverityLabel } from './ReportDetails';
 
 const PreupgradeReportsTable = ({ data = {} }) => {
   const [error, setError] = useState(null);
-  const [isExpanded, setIsExpanded] = useState(false);
+
+  const [isReportExpanded, setIsReportExpanded] = useState(false); // Outer expansion state (Leapp Report Section)
   const [pagination, setPagination] = useState({ page: 1, perPage: 5 });
   const [reportData, setReportData] = useState(null);
   const [status, setStatus] = useState(STATUS.RESOLVED);
+  const [expandedRowIds, setExpandedRowIds] = useState(new Set()); // Inner table expansion state (Rows)
+
   const dispatch = useDispatch();
   // eslint-disable-next-line camelcase
   const isLeappJob = data?.template_name?.includes('Run preupgrade via Leapp');
@@ -67,7 +57,7 @@ const PreupgradeReportsTable = ({ data = {} }) => {
 
   useEffect(() => {
     let isMounted = true;
-    if (!isLeappJob || !isExpanded || reportData) {
+    if (!isLeappJob || !isReportExpanded || reportData) {
       return undefined;
     }
     setStatus(STATUS.PENDING);
@@ -117,7 +107,7 @@ const PreupgradeReportsTable = ({ data = {} }) => {
     return () => {
       isMounted = false;
     };
-  }, [isExpanded, data.id, isLeappJob, reportData, dispatch]);
+  }, [isReportExpanded, data.id, isLeappJob, reportData, dispatch]);
 
   // eslint-disable-next-line camelcase
   const entries = reportData?.preupgrade_report_entries || [];
@@ -129,15 +119,43 @@ const PreupgradeReportsTable = ({ data = {} }) => {
       page: newParams.page || prev.page,
       perPage: newParams.per_page || prev.perPage,
     }));
+    setExpandedRowIds(new Set());
   };
+
+  const toggleRowExpansion = (id, isExpanding) => {
+    setExpandedRowIds(prev => {
+      const newSet = new Set(prev);
+      if (isExpanding) {
+        newSet.add(id);
+      } else {
+        newSet.delete(id);
+      }
+      return newSet;
+    });
+  };
+
+  const areAllRowsExpanded =
+    pagedEntries.length > 0 &&
+    pagedEntries.every(entry => expandedRowIds.has(entry.id));
+
+  const onExpandAll = () => {
+    setExpandedRowIds(() => {
+      if (areAllRowsExpanded) {
+        return new Set();
+      }
+      return new Set(pagedEntries.map(e => e.id));
+    });
+  };
+
+  const [columnKeys, keysToColumnNames] = getColumnHelpers(columns);
 
   if (!isLeappJob) return null;
 
   return (
     <ExpandableSection
       className="leapp-report-section"
-      isExpanded={isExpanded}
-      onToggle={(_event, val) => setIsExpanded(val)}
+      isExpanded={isReportExpanded}
+      onToggle={(_event, val) => setIsReportExpanded(val)}
       toggleText={__('Leapp preupgrade report')}
     >
       <Table
@@ -161,14 +179,53 @@ const PreupgradeReportsTable = ({ data = {} }) => {
         isDeleteable={false}
         emptyMessage={__('The preupgrade report shows no issues.')}
         setParams={handleParamsChange}
-      />
+        childrenOutsideTbody
+        onExpandAll={onExpandAll}
+        // Inverted per PatternFly implementation to ensure correct toggle icon state
+        areAllRowsExpanded={!areAllRowsExpanded}
+      >
+        {pagedEntries.map((entry, rowIndex) => {
+          const isRowExpanded = expandedRowIds.has(entry.id);
+          return (
+            <Tbody key={entry.id} isExpanded={isRowExpanded}>
+              <Tr ouiaId={`table-row-${rowIndex}`}>
+                <Td
+                  expand={{
+                    rowIndex,
+                    isExpanded: isRowExpanded,
+                    onToggle: (_event, _rowIndex, isOpen) =>
+                      toggleRowExpansion(entry.id, isOpen),
+                  }}
+                />
+                {columnKeys.map(key => (
+                  <Td key={key} dataLabel={keysToColumnNames[key]}>
+                    {columns[key].wrapper
+                      ? columns[key].wrapper(entry)
+                      : entry[key]}
+                  </Td>
+                ))}
+              </Tr>
+              <Tr
+                isExpanded={isRowExpanded}
+                ouiaId={`table-row-details-${rowIndex}`}
+              >
+                <Td colSpan={columnKeys.length + 1}>
+                  <ExpandableRowContent>
+                    {isRowExpanded && <ReportDetails entry={entry} />}
+                  </ExpandableRowContent>
+                </Td>
+              </Tr>
+            </Tbody>
+          );
+        })}
+      </Table>
     </ExpandableSection>
   );
 };
 
 PreupgradeReportsTable.propTypes = {
   data: PropTypes.shape({
-    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    id: PropTypes.number,
     template_name: PropTypes.string,
   }),
 };


### PR DESCRIPTION
Adds expanding functionality and expandable information to the new Leapp preupgrade report table on the job invocation detail page.

Before:
<img width="1682" height="812" alt="image" src="https://github.com/user-attachments/assets/df527fbf-51de-49f3-8aec-1d6c8d7b50d4" />

After:
<img width="1682" height="812" alt="image" src="https://github.com/user-attachments/assets/876d0932-c308-45ca-8f0b-4c54602e8dce" />

The test was created with the help of AI.