### PR TITLE
Test with Foreman PR 11004

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,3 +19,4 @@ jobs:
     uses: theforeman/actions/.github/workflows/foreman_plugin.yml@v0
     with:
       plugin: foreman_leapp
+      foreman_version: refs/pull/11004/head


### PR DESCRIPTION
The Ruby CI is green:
<img width="1307" height="675" alt="Screenshot-1780321864316" src="https://github.com/user-attachments/assets/ade9ee2f-2ab5-433a-8393-ab383dd35608" />

The JS CI failure is not related (need to update the snapshots)